### PR TITLE
Add support for lxc-execute

### DIFF
--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -101,7 +101,8 @@ type LxcExecuteDriverConfig struct {
 
 // NewLxcDriver returns a new instance of the LXC driver
 func NewLxcDriver(ctx *DriverContext) Driver {
-	return &LxcDriver{DriverContext: *ctx}
+	d := &LxcDriver{DriverContext: *ctx}
+	return d
 }
 
 // Validate validates the lxc driver configuration
@@ -306,6 +307,11 @@ func (d *LxcDriver) startWithCleanup(ctx *ExecContext, task *structs.Task) (*Sta
 		return nil, err, noCleanup
 	}
 
+	d.lxcPath = lxc.DefaultConfigPath()
+	if path := d.config.Read("driver.lxc.path"); path != "" {
+		d.lxcPath = path
+	}
+
 	containerName := d.getContainerName(task)
 	c, err := lxc.NewContainer(containerName, d.lxcPath)
 	if err != nil {
@@ -437,7 +443,9 @@ func (d *LxcDriver) executeContainer(ctx *ExecContext, c *lxc.Container, task *s
 	}
 
 	vgName := baseLvName[:strings.Index(baseLvName, "/")]
-
+	if len(vgName) == 0 {
+		return nil, fmt.Errorf("could not parse volume group name from '%v':, baseLvName")
+	}
 	tr := func(s string) string {
 		return strings.Replace(s, "-", "--", -1)
 	}

--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
+	"text/template"
 	"time"
 
 	"github.com/hashicorp/nomad/client/config"
@@ -56,10 +58,23 @@ func init() {
 type LxcDriver struct {
 	DriverContext
 	fingerprint.StaticFingerprinter
+	lxcPath string
 }
 
-// LxcDriverConfig is the configuration of the LXC Container
-type LxcDriverConfig struct {
+// LxcCommonDriverConfig is configuration that's common between
+// container types - new containers created with Create and run with
+// Start; and containers created from a rootfs clone and started using
+// StartExecute.
+type LxcCommonDriverConfig struct {
+	LogLevel   string   `mapstructure:"log_level"`
+	Verbosity  string   `mapstructure:"verbosity"`
+	UseExecute bool     `mapstructure:"use_execute"`
+	Volumes    []string `mapstructure:"volumes"`
+}
+
+// LxcStartDriverConfig is the configuration for containers that will
+// be created with Create and run with Start
+type LxcStartDriverConfig struct {
 	Template             string
 	Distro               string
 	Release              string
@@ -72,9 +87,16 @@ type LxcDriverConfig struct {
 	FlushCache           bool     `mapstructure:"flush_cache"`
 	ForceCache           bool     `mapstructure:"force_cache"`
 	TemplateArgs         []string `mapstructure:"template_args"`
-	LogLevel             string   `mapstructure:"log_level"`
-	Verbosity            string
-	Volumes              []string `mapstructure:"volumes"`
+	LxcCommonDriverConfig
+}
+
+// LxcExecuteDriverConfig is configuration for containers that will be
+// created by cloning a rootfs and run using StartExecute
+type LxcExecuteDriverConfig struct {
+	LxcCommonDriverConfig
+	BaseRootFsPath string   `mapstructure:"base_rootfs_path"`
+	BaseConfigPath string   `mapstructure:"base_config_path"`
+	CmdArgs        []string `mapstructure:"cmd_args"`
 }
 
 // NewLxcDriver returns a new instance of the LXC driver
@@ -84,6 +106,24 @@ func NewLxcDriver(ctx *DriverContext) Driver {
 
 // Validate validates the lxc driver configuration
 func (d *LxcDriver) Validate(config map[string]interface{}) error {
+	commonFieldSchema := map[string]*fields.FieldSchema{
+		"log_level": {
+			Type:     fields.TypeString,
+			Required: false,
+		},
+		"verbosity": {
+			Type:     fields.TypeString,
+			Required: false,
+		},
+		"use_execute": {
+			Type:     fields.TypeBool,
+			Required: false,
+		},
+		"volumes": {
+			Type:     fields.TypeArray,
+			Required: false,
+		},
+	}
 	fd := &fields.FieldData{
 		Raw: config,
 		Schema: map[string]*fields.FieldSchema{
@@ -135,27 +175,61 @@ func (d *LxcDriver) Validate(config map[string]interface{}) error {
 				Type:     fields.TypeArray,
 				Required: false,
 			},
-			"log_level": {
+		},
+	}
+	for k, v := range commonFieldSchema {
+		fd.Schema[k] = v
+	}
+
+	execFd := &fields.FieldData{
+		Raw: config,
+		Schema: map[string]*fields.FieldSchema{
+			"base_config_path": {
 				Type:     fields.TypeString,
-				Required: false,
+				Required: true,
 			},
-			"verbosity": {
+			"base_rootfs_path": {
 				Type:     fields.TypeString,
-				Required: false,
+				Required: true,
 			},
-			"volumes": {
+			"cmd_args": {
 				Type:     fields.TypeArray,
 				Required: false,
+				Default:  []string{},
 			},
 		},
 	}
 
-	if err := fd.Validate(); err != nil {
-		return err
+	for k, v := range commonFieldSchema {
+		execFd.Schema[k] = v
 	}
 
-	volumes, _ := fd.GetOk("volumes")
-	for _, volDesc := range volumes.([]interface{}) {
+	// default is to use lxc-start
+	useExecute := false
+	execConfig, ok := config["use_execute"]
+	if ok {
+		useExecute, ok = execConfig.(bool)
+		if !ok {
+			return fmt.Errorf("invalid value for use_execute config: %v", execConfig)
+		}
+	}
+	var volumes interface{}
+	if useExecute {
+		if err := execFd.Validate(); err != nil {
+			return err
+		}
+		volumes, _ = execFd.GetOk("volumes")
+	} else {
+		if err := fd.Validate(); err != nil {
+			return err
+		}
+		volumes, _ = fd.GetOk("volumes")
+	}
+	return d.validateVolumesConfig(volumes.([]interface{}))
+}
+
+func (d *LxcDriver) validateVolumesConfig(volumes []interface{}) error {
+	for _, volDesc := range volumes {
 		volStr := volDesc.(string)
 		paths := strings.Split(volStr, ":")
 		if len(paths) != 2 {
@@ -168,7 +242,6 @@ func (d *LxcDriver) Validate(config map[string]interface{}) error {
 			return fmt.Errorf("unsupported absolute container mount point: '%s'", paths[1])
 		}
 	}
-
 	return nil
 }
 
@@ -201,11 +274,17 @@ func (d *LxcDriver) Fingerprint(cfg *config.Config, node *structs.Node) (bool, e
 		node.Attributes["driver."+lxcVolumesConfigOption] = "1"
 	}
 
+	node.Attributes["driver.lxc.execute"] = "true"
+
 	return true, nil
 }
 
-func (d *LxcDriver) Prestart(*ExecContext, *structs.Task) (*PrestartResponse, error) {
+func (d *LxcDriver) Prestart(_ *ExecContext, task *structs.Task) (*PrestartResponse, error) {
 	return nil, nil
+}
+
+func (d *LxcDriver) getContainerName(task *structs.Task) string {
+	return fmt.Sprintf("%s-%s", task.Name, d.DriverContext.allocID)
 }
 
 // Start starts the LXC Driver
@@ -221,23 +300,20 @@ func (d *LxcDriver) Start(ctx *ExecContext, task *structs.Task) (*StartResponse,
 
 func (d *LxcDriver) startWithCleanup(ctx *ExecContext, task *structs.Task) (*StartResponse, error, func() error) {
 	noCleanup := func() error { return nil }
-	var driverConfig LxcDriverConfig
-	if err := mapstructure.WeakDecode(task.Config, &driverConfig); err != nil {
+
+	var commonConfig LxcCommonDriverConfig
+	if err := mapstructure.WeakDecode(task.Config, &commonConfig); err != nil {
 		return nil, err, noCleanup
 	}
-	lxcPath := lxc.DefaultConfigPath()
-	if path := d.config.Read("driver.lxc.path"); path != "" {
-		lxcPath = path
-	}
 
-	containerName := fmt.Sprintf("%s-%s", task.Name, d.DriverContext.allocID)
-	c, err := lxc.NewContainer(containerName, lxcPath)
+	containerName := d.getContainerName(task)
+	c, err := lxc.NewContainer(containerName, d.lxcPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize container: %v", err), noCleanup
 	}
 
 	var verbosity lxc.Verbosity
-	switch driverConfig.Verbosity {
+	switch commonConfig.Verbosity {
 	case "verbose":
 		verbosity = lxc.Verbose
 	case "", "quiet":
@@ -248,7 +324,7 @@ func (d *LxcDriver) startWithCleanup(ctx *ExecContext, task *structs.Task) (*Sta
 	c.SetVerbosity(verbosity)
 
 	var logLevel lxc.LogLevel
-	switch driverConfig.LogLevel {
+	switch commonConfig.LogLevel {
 	case "trace":
 		logLevel = lxc.TRACE
 	case "debug":
@@ -267,54 +343,39 @@ func (d *LxcDriver) startWithCleanup(ctx *ExecContext, task *structs.Task) (*Sta
 	logFile := filepath.Join(ctx.TaskDir.Dir, fmt.Sprintf("%v-lxc.log", task.Name))
 	c.SetLogFile(logFile)
 
+	if commonConfig.UseExecute {
+		d.logger.Printf("[INFO] Using lxc-execute to start application container")
+		return d.executeContainer(ctx, c, task, &commonConfig)
+	} else {
+		d.logger.Printf("[INFO] Using lxc-start to start system container")
+		return d.startContainer(ctx, c, task, &commonConfig)
+	}
+}
+
+func (d *LxcDriver) startContainer(ctx *ExecContext, c *lxc.Container, task *structs.Task, commonConfig *LxcCommonDriverConfig) (*StartResponse, error, func() error) {
+	noCleanup := func() error { return nil }
+
+	var startConfig LxcStartDriverConfig
+	if err := mapstructure.WeakDecode(task.Config, &startConfig); err != nil {
+		return nil, err, noCleanup
+	}
+
 	options := lxc.TemplateOptions{
-		Template:             driverConfig.Template,
-		Distro:               driverConfig.Distro,
-		Release:              driverConfig.Release,
-		Arch:                 driverConfig.Arch,
-		FlushCache:           driverConfig.FlushCache,
-		DisableGPGValidation: driverConfig.DisableGPGValidation,
-		ExtraArgs:            driverConfig.TemplateArgs,
+		Template:             startConfig.Template,
+		Distro:               startConfig.Distro,
+		Release:              startConfig.Release,
+		Arch:                 startConfig.Arch,
+		FlushCache:           startConfig.FlushCache,
+		DisableGPGValidation: startConfig.DisableGPGValidation,
+		ExtraArgs:            startConfig.TemplateArgs,
 	}
 
 	if err := c.Create(options); err != nil {
 		return nil, fmt.Errorf("unable to create container: %v", err), noCleanup
 	}
 
-	// Set the network type to none
-	if err := c.SetConfigItem("lxc.network.type", "none"); err != nil {
-		return nil, fmt.Errorf("error setting network type configuration: %v", err), c.Destroy
-	}
-
-	// Bind mount the shared alloc dir and task local dir in the container
-	mounts := []string{
-		fmt.Sprintf("%s local none rw,bind,create=dir", ctx.TaskDir.LocalDir),
-		fmt.Sprintf("%s alloc none rw,bind,create=dir", ctx.TaskDir.SharedAllocDir),
-		fmt.Sprintf("%s secrets none rw,bind,create=dir", ctx.TaskDir.SecretsDir),
-	}
-
-	volumesEnabled := d.config.ReadBoolDefault(lxcVolumesConfigOption, lxcVolumesConfigDefault)
-
-	for _, volDesc := range driverConfig.Volumes {
-		// the format was checked in Validate()
-		paths := strings.Split(volDesc, ":")
-
-		if filepath.IsAbs(paths[0]) {
-			if !volumesEnabled {
-				return nil, fmt.Errorf("absolute bind-mount volume in config but '%v' is false", lxcVolumesConfigOption), c.Destroy
-			}
-		} else {
-			// Relative source paths are treated as relative to alloc dir
-			paths[0] = filepath.Join(ctx.TaskDir.Dir, paths[0])
-		}
-
-		mounts = append(mounts, fmt.Sprintf("%s %s none rw,bind,create=dir", paths[0], paths[1]))
-	}
-
-	for _, mnt := range mounts {
-		if err := c.SetConfigItem("lxc.mount.entry", mnt); err != nil {
-			return nil, fmt.Errorf("error setting bind mount %q error: %v", mnt, err), c.Destroy
-		}
+	if err := d.setCommonContainerConfig(ctx, c, commonConfig); err != nil {
+		return nil, err, c.Destroy
 	}
 
 	// Start the container
@@ -329,18 +390,14 @@ func (d *LxcDriver) startWithCleanup(ctx *ExecContext, task *structs.Task) (*Sta
 		return c.Destroy()
 	}
 
-	// Set the resource limits
-	if err := c.SetMemoryLimit(lxc.ByteSize(task.Resources.MemoryMB) * lxc.MB); err != nil {
-		return nil, fmt.Errorf("unable to set memory limits: %v", err), stopAndDestroyCleanup
-	}
-	if err := c.SetCgroupItem("cpu.shares", strconv.Itoa(task.Resources.CPU)); err != nil {
-		return nil, fmt.Errorf("unable to set cpu shares: %v", err), stopAndDestroyCleanup
+	if err := setLimitsOnContainer(c, task); err != nil {
+		return nil, err, stopAndDestroyCleanup
 	}
 
 	h := lxcDriverHandle{
 		container:      c,
 		initPid:        c.InitPid(),
-		lxcPath:        lxcPath,
+		lxcPath:        d.lxcPath,
 		logger:         d.logger,
 		killTimeout:    GetKillTimeout(task.KillTimeout, d.DriverContext.config.MaxKillTimeout),
 		maxKillTimeout: d.DriverContext.config.MaxKillTimeout,
@@ -356,7 +413,174 @@ func (d *LxcDriver) startWithCleanup(ctx *ExecContext, task *structs.Task) (*Sta
 	return &StartResponse{Handle: &h}, nil, noCleanup
 }
 
-func (d *LxcDriver) Cleanup(*ExecContext, *CreatedResources) error { return nil }
+func (d *LxcDriver) executeContainer(ctx *ExecContext, c *lxc.Container, task *structs.Task, commonConfig *LxcCommonDriverConfig) (*StartResponse, error, func() error) {
+	noCleanup := func() error { return nil }
+	var executeConfig LxcExecuteDriverConfig
+	if err := mapstructure.WeakDecode(task.Config, &executeConfig); err != nil {
+		return nil, err, noCleanup
+	}
+
+	containerPath := filepath.Join(d.lxcPath, c.Name())
+	containerRootfsPath := filepath.Join(containerPath, "rootfs")
+	if err := os.MkdirAll(containerRootfsPath, 0711); err != nil {
+		return nil, fmt.Errorf("unable to create container directory at %s", containerPath), noCleanup
+	}
+
+	if executeConfig.BaseRootFsPath[:4] != "lvm:" {
+		return nil, fmt.Errorf("only LVM is supported as a base to clone from"), noCleanup
+	}
+
+	baseLvName := executeConfig.BaseRootFsPath[4:]
+	lvCreateCmd := exec.Command("lvcreate", "-kn", "-n", c.Name(), "-s", baseLvName)
+	if err := lvCreateCmd.Run(); err != nil {
+		return nil, fmt.Errorf("could not create thin pool snapshot with cmd '%v': %v: %s", lvCreateCmd.Args, err, err.(*exec.ExitError).Stderr), noCleanup
+	}
+
+	vgName := baseLvName[:strings.Index(baseLvName, "/")]
+
+	tr := func(s string) string {
+		return strings.Replace(s, "-", "--", -1)
+	}
+
+	storageName := fmt.Sprintf("lvm:/dev/mapper/%s-%s", tr(vgName), tr(c.Name()))
+
+	configTemplate := struct {
+		RootFSPath    string
+		ContainerName string
+	}{
+		storageName,
+		c.Name(),
+	}
+
+	newConfigFilePath := filepath.Join(d.lxcPath, c.Name(), "config")
+	newConfigFile, err := os.Create(newConfigFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create new config file '%s': %v", newConfigFilePath, err), noCleanup
+	}
+	defer newConfigFile.Close()
+	removeConfigCleanup := func() error {
+		return os.Remove(newConfigFilePath)
+	}
+
+	if err := os.Chmod(newConfigFilePath, 0777); err != nil {
+		return nil, fmt.Errorf("unable to change permissions on config file"), removeConfigCleanup
+	}
+
+	tmpl, err := template.ParseFiles(executeConfig.BaseConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse config template in '%v': %v",
+			executeConfig.BaseConfigPath, err), removeConfigCleanup
+	}
+
+	if err := tmpl.Execute(newConfigFile, configTemplate); err != nil {
+		return nil, fmt.Errorf("Error executing config file template: %v", err), removeConfigCleanup
+	}
+
+	d.logger.Printf("[INFO] %s config path is %s", c.Name(), newConfigFilePath)
+	if err := c.LoadConfigFile(newConfigFilePath); err != nil {
+		return nil, fmt.Errorf("unable to read config file for container: %v", err), removeConfigCleanup
+	}
+
+	if err := d.setCommonContainerConfig(ctx, c, commonConfig); err != nil {
+		return nil, err, removeConfigCleanup
+	}
+
+	if err := c.StartExecute(executeConfig.CmdArgs); err != nil {
+		return nil, fmt.Errorf("unable to execute with args '%v': %v", executeConfig.CmdArgs, err), removeConfigCleanup
+	}
+
+	stopAndRemoveConfigCleanup := func() error {
+		removeConfigCleanup()
+		if err := c.Stop(); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if err := setLimitsOnContainer(c, task); err != nil {
+		return nil, err, stopAndRemoveConfigCleanup
+	}
+
+	h := lxcDriverHandle{
+		container:      c,
+		initPid:        c.InitPid(),
+		lxcPath:        d.lxcPath,
+		logger:         d.logger,
+		killTimeout:    GetKillTimeout(task.KillTimeout, d.DriverContext.config.MaxKillTimeout),
+		maxKillTimeout: d.DriverContext.config.MaxKillTimeout,
+		totalCpuStats:  stats.NewCpuStats(),
+		userCpuStats:   stats.NewCpuStats(),
+		systemCpuStats: stats.NewCpuStats(),
+		waitCh:         make(chan *dstructs.WaitResult, 1),
+		doneCh:         make(chan bool, 1),
+	}
+
+	go h.run()
+
+	return &StartResponse{Handle: &h}, nil, noCleanup
+
+}
+
+func (d *LxcDriver) setCommonContainerConfig(ctx *ExecContext, c *lxc.Container, commonConfig *LxcCommonDriverConfig) error {
+	// Set the network type to none
+	if err := c.SetConfigItem("lxc.network.type", "none"); err != nil {
+		return fmt.Errorf("error setting network type configuration: %v", err)
+	}
+
+	// Bind mount the shared alloc dir and task local dir in the container
+	mounts := []string{
+		fmt.Sprintf("%s local none rw,bind,create=dir", ctx.TaskDir.LocalDir),
+		fmt.Sprintf("%s alloc none rw,bind,create=dir", ctx.TaskDir.SharedAllocDir),
+		fmt.Sprintf("%s secrets none rw,bind,create=dir", ctx.TaskDir.SecretsDir),
+	}
+	for _, mnt := range mounts {
+		if err := c.SetConfigItem("lxc.mount.entry", mnt); err != nil {
+			return fmt.Errorf("error setting bind mount %q error: %v", mnt, err)
+		}
+	}
+
+	volumesEnabled := d.config.ReadBoolDefault(lxcVolumesConfigOption, lxcVolumesConfigDefault)
+
+	for _, volDesc := range commonConfig.Volumes {
+		// the format was checked in Validate()
+		paths := strings.Split(volDesc, ":")
+
+		if filepath.IsAbs(paths[0]) {
+			if !volumesEnabled {
+				return fmt.Errorf("absolute bind-mount volume in config but '%v' is false", lxcVolumesConfigOption)
+			}
+		} else {
+			// Relative source paths are treated as relative to alloc dir
+			paths[0] = filepath.Join(ctx.TaskDir.Dir, paths[0])
+		}
+
+		mounts = append(mounts, fmt.Sprintf("%s %s none rw,bind,create=dir", paths[0], paths[1]))
+	}
+
+	for _, mnt := range mounts {
+		if err := c.SetConfigItem("lxc.mount.entry", mnt); err != nil {
+			return fmt.Errorf("error setting bind mount %q error: %v", mnt, err)
+		}
+	}
+
+	return nil
+}
+
+func setLimitsOnContainer(c *lxc.Container, task *structs.Task) error {
+	// Set the resource limits
+	if err := c.SetMemoryLimit(lxc.ByteSize(task.Resources.MemoryMB) * lxc.MB); err != nil {
+		return fmt.Errorf("unable to set memory limits: %v", err)
+	}
+	if err := c.SetCgroupItem("cpu.shares", strconv.Itoa(task.Resources.CPU)); err != nil {
+		return fmt.Errorf("unable to set cpu shares: %v", err)
+	}
+	return nil
+}
+
+func (d *LxcDriver) Cleanup(ctx *ExecContext, resources *CreatedResources) error {
+
+	return nil
+}
 
 // Open creates the driver to monitor an existing LXC container
 func (d *LxcDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error) {
@@ -369,7 +593,7 @@ func (d *LxcDriver) Open(ctx *ExecContext, handleID string) (DriverHandle, error
 	containers := lxc.Containers(pid.LxcPath)
 	for _, c := range containers {
 		if c.Name() == pid.ContainerName {
-			container = &c
+			container = c
 			break
 		}
 	}
@@ -453,11 +677,21 @@ func (h *lxcDriverHandle) Kill() error {
 	name := h.container.Name()
 
 	h.logger.Printf("[INFO] driver.lxc: shutting down container %q", name)
-	if err := h.container.Shutdown(h.killTimeout); err != nil {
-		h.logger.Printf("[INFO] driver.lxc: shutting down container %q failed: %v", name, err)
-		if err := h.container.Stop(); err != nil {
-			h.logger.Printf("[ERR] driver.lxc: error stopping container %q: %v", name, err)
+
+	if h.container.Running() {
+		if err := h.container.Shutdown(h.killTimeout); err != nil {
+			h.logger.Printf("[INFO] driver.lxc: shutting down container %q failed: %v", name, err)
+
+			if err := h.container.Stop(); err != nil {
+				h.logger.Printf("[WARN] driver.lxc: error stopping container %q: %v", name, err)
+				return fmt.Errorf("could not stop container: %v", err)
+			}
 		}
+	}
+
+	if err := h.container.Destroy(); err != nil {
+		h.logger.Printf("[WARN] driver.lxc: error destroying container %q: %v.", name, err)
+		return fmt.Errorf("could not destroy container")
 	}
 
 	close(h.doneCh)

--- a/client/driver/lxc_test.go
+++ b/client/driver/lxc_test.go
@@ -261,7 +261,7 @@ func TestLxcDriver_Volumes_ConfigValidation(t *testing.T) {
 		}
 	}
 	if err := testVolumeConfig(t, []string{"abc:def"}); err != nil {
-		t.Fatalf("error in validate for syntactically valid config abc:def")
+		t.Fatalf("error in validate for syntactically valid config abc:def was %v", err)
 	}
 }
 

--- a/vendor/gopkg.in/lxc/go-lxc.v2/Makefile
+++ b/vendor/gopkg.in/lxc/go-lxc.v2/Makefile
@@ -45,4 +45,16 @@ escape-analysis:
 ctags:
 	@ctags -R --languages=c,go
 
+scope:
+	@echo "$(OK_COLOR)==> Exported container calls in container.go $(NO_COLOR)"
+	@/bin/grep -E "\bc+\.([A-Z])\w+" container.go || true
+
+setup-test-cgroup:
+	for d in /sys/fs/cgroup/*; do \
+	    [ -f $$d/cgroup.clone_children ] && echo 1 | sudo tee $$d/cgroup.clone_children; \
+	    [ -f $$d/cgroup.use_hierarchy ] && echo 1 | sudo tee $$d/cgroup.use_hierarchy; \
+	    sudo mkdir -p $$d/lxc; \
+	    sudo chown -R $$USER: $$d/lxc; \
+	done
+
 .PHONY: all format test doc vet lint ctags

--- a/vendor/gopkg.in/lxc/go-lxc.v2/container.go
+++ b/vendor/gopkg.in/lxc/go-lxc.v2/container.go
@@ -16,18 +16,21 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 	"unsafe"
 )
 
 // Container struct
 type Container struct {
-	container *C.struct_lxc_container
 	mu        sync.RWMutex
+	container *C.struct_lxc_container
 
 	verbosity Verbosity
 }
@@ -52,20 +55,20 @@ const (
 )
 
 func (c *Container) makeSure(flags int) error {
-	if flags&isDefined != 0 && !c.Defined() {
-		return ErrNotDefined
+	if flags&isDefined != 0 && !c.defined() {
+		return fmt.Errorf("%s: %q", ErrNotDefined, c.name())
 	}
 
-	if flags&isNotDefined != 0 && c.Defined() {
-		return ErrAlreadyDefined
+	if flags&isNotDefined != 0 && c.defined() {
+		return fmt.Errorf("%s: %q", ErrAlreadyDefined, c.name())
 	}
 
-	if flags&isRunning != 0 && !c.Running() {
-		return ErrNotRunning
+	if flags&isRunning != 0 && !c.running() {
+		return fmt.Errorf("%s: %q", ErrNotRunning, c.name())
 	}
 
-	if flags&isNotRunning != 0 && c.Running() {
-		return ErrAlreadyRunning
+	if flags&isNotRunning != 0 && c.running() {
+		return fmt.Errorf("%s: %q", ErrAlreadyRunning, c.name())
 	}
 
 	if flags&isPrivileged != 0 && os.Geteuid() != 0 {
@@ -84,7 +87,7 @@ func (c *Container) makeSure(flags int) error {
 }
 
 func (c *Container) cgroupItemAsByteSize(filename string, missing error) (ByteSize, error) {
-	size, err := strconv.ParseFloat(c.CgroupItem(filename)[0], 64)
+	size, err := strconv.ParseFloat(c.cgroupItem(filename)[0], 64)
 	if err != nil {
 		return -1, missing
 	}
@@ -92,10 +95,14 @@ func (c *Container) cgroupItemAsByteSize(filename string, missing error) (ByteSi
 }
 
 func (c *Container) setCgroupItemWithByteSize(filename string, limit ByteSize, missing error) error {
-	if err := c.SetCgroupItem(filename, fmt.Sprintf("%.f", limit)); err != nil {
+	if err := c.setCgroupItem(filename, fmt.Sprintf("%.f", limit)); err != nil {
 		return missing
 	}
 	return nil
+}
+
+func (c *Container) name() string {
+	return C.GoString(c.container.name)
 }
 
 // Name returns the name of the container.
@@ -103,7 +110,20 @@ func (c *Container) Name() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return C.GoString(c.container.name)
+	return c.name()
+}
+
+// String returns the string represantation of container.
+func (c *Container) String() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return path.Join(c.configPath(), c.name())
+}
+
+// Caller needs to hold the lock
+func (c *Container) defined() bool {
+	return bool(C.go_lxc_defined(c.container))
 }
 
 // Defined returns true if the container is already defined.
@@ -111,7 +131,12 @@ func (c *Container) Defined() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return bool(C.go_lxc_defined(c.container))
+	return c.defined()
+}
+
+// Caller needs to hold the lock
+func (c *Container) running() bool {
+	return bool(C.go_lxc_running(c.container))
 }
 
 // Running returns true if the container is already running.
@@ -119,7 +144,7 @@ func (c *Container) Running() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return bool(C.go_lxc_running(c.container))
+	return c.running()
 }
 
 // Controllable returns true if the caller can control the container.
@@ -132,12 +157,12 @@ func (c *Container) Controllable() bool {
 
 // CreateSnapshot creates a new snapshot.
 func (c *Container) CreateSnapshot() (*Snapshot, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isDefined | isNotRunning); err != nil {
 		return nil, err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	ret := int(C.go_lxc_snapshot(c.container))
 	if ret < 0 {
@@ -148,12 +173,12 @@ func (c *Container) CreateSnapshot() (*Snapshot, error) {
 
 // RestoreSnapshot creates a new container based on a snapshot.
 func (c *Container) RestoreSnapshot(snapshot Snapshot, name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isDefined); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
@@ -169,12 +194,12 @@ func (c *Container) RestoreSnapshot(snapshot Snapshot, name string) error {
 
 // DestroySnapshot destroys the specified snapshot.
 func (c *Container) DestroySnapshot(snapshot Snapshot) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isDefined); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	csnapname := C.CString(snapshot.Name)
 	defer C.free(unsafe.Pointer(csnapname))
@@ -187,12 +212,12 @@ func (c *Container) DestroySnapshot(snapshot Snapshot) error {
 
 // DestroyAllSnapshots destroys all the snapshot.
 func (c *Container) DestroyAllSnapshots() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isDefined | isGreaterEqualThanLXC11); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if !bool(C.go_lxc_snapshot_destroy_all(c.container)) {
 		return ErrDestroyAllSnapshotsFailed
@@ -202,12 +227,12 @@ func (c *Container) DestroyAllSnapshots() error {
 
 // Snapshots returns the list of container snapshots.
 func (c *Container) Snapshots() ([]Snapshot, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isDefined); err != nil {
 		return nil, err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	var csnapshots *C.struct_lxc_snapshot
 
@@ -238,12 +263,17 @@ func (c *Container) Snapshots() ([]Snapshot, error) {
 	return snapshots, nil
 }
 
+// Caller needs to hold the lock
+func (c *Container) state() State {
+	return StateMap[C.GoString(C.go_lxc_state(c.container))]
+}
+
 // State returns the state of the container.
 func (c *Container) State() State {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return StateMap[C.GoString(C.go_lxc_state(c.container))]
+	return c.state()
 }
 
 // InitPid returns the process ID of the container's init process
@@ -296,16 +326,13 @@ func (c *Container) SetVerbosity(verbosity Verbosity) {
 
 // Freeze freezes the running container.
 func (c *Container) Freeze() error {
-	if err := c.makeSure(isRunning); err != nil {
-		return err
-	}
-
-	if c.State() == FROZEN {
-		return ErrAlreadyFrozen
-	}
-
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// check the state using lockless version
+	if c.state() == FROZEN {
+		return ErrAlreadyFrozen
+	}
 
 	if !bool(C.go_lxc_freeze(c.container)) {
 		return ErrFreezeFailed
@@ -316,16 +343,17 @@ func (c *Container) Freeze() error {
 
 // Unfreeze thaws the frozen container.
 func (c *Container) Unfreeze() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return err
 	}
 
-	if c.State() != FROZEN {
+	// check the state using lockless version
+	if c.state() != FROZEN {
 		return ErrNotFrozen
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if !bool(C.go_lxc_unfreeze(c.container)) {
 		return ErrUnfreezeFailed
@@ -336,6 +364,9 @@ func (c *Container) Unfreeze() error {
 
 // Create creates the container using given TemplateOptions
 func (c *Container) Create(options TemplateOptions) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	// FIXME: Support bdev_specs
 	//
 	// bdev_specs:
@@ -347,9 +378,6 @@ func (c *Container) Create(options TemplateOptions) error {
 		return err
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	// use download template if not set
 	if options.Template == "" {
 		options.Template = "download"
@@ -358,11 +386,6 @@ func (c *Container) Create(options TemplateOptions) error {
 	// use Directory backend if not set
 	if options.Backend == 0 {
 		options.Backend = Directory
-	}
-
-	// unprivileged users are only allowed to use "download" template
-	if os.Geteuid() != 0 && options.Template != "download" {
-		return ErrTemplateNotAllowed
 	}
 
 	var args []string
@@ -439,12 +462,12 @@ func (c *Container) Create(options TemplateOptions) error {
 
 // Start starts the container.
 func (c *Container) Start() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isNotRunning); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if !bool(C.go_lxc_start(c.container, 0, nil)) {
 		return ErrStartFailed
@@ -452,17 +475,53 @@ func (c *Container) Start() error {
 	return nil
 }
 
+// StartWithArgs starts the container using given arguments.
+func (c *Container) StartWithArgs(args []string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.makeSure(isNotRunning); err != nil {
+		return err
+	}
+
+	if !bool(C.go_lxc_start(c.container, 0, makeNullTerminatedArgs(args))) {
+		return ErrStartFailed
+	}
+	return nil
+}
+
+// StartExecute starts a container. It runs a minimal init as PID 1 and the
+// requested program as the second process.
+func (c *Container) StartExecute(args []string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.makeSure(isNotRunning); err != nil {
+		return err
+	}
+
+	if !bool(C.go_lxc_start(c.container, 1, makeNullTerminatedArgs(args))) {
+		return ErrStartFailed
+	}
+
+	return nil
+}
+
 // Execute executes the given command in a temporary container.
 func (c *Container) Execute(args ...string) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isNotDefined); err != nil {
 		return nil, err
 	}
 
-	cargs := []string{"lxc-execute", "-n", c.Name(), "-P", c.ConfigPath(), "--"}
-	cargs = append(cargs, args...)
+	os.MkdirAll(filepath.Join(c.configPath(), c.name()), 0700)
+	c.saveConfigFile(filepath.Join(c.configPath(), c.name(), "config"))
+	defer os.RemoveAll(filepath.Join(c.configPath(), c.name()))
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	cargs := []string{"lxc-execute", "-n", c.name(), "-P", c.configPath(), "--"}
+	cargs = append(cargs, args...)
 
 	// FIXME: Go runtime and src/lxc/start.c signal_handler are not playing nice together so use lxc-execute for now
 	// go-nuts thread: https://groups.google.com/forum/#!msg/golang-nuts/h9GbvfYv83w/5Ly_jvOr86wJ
@@ -472,28 +531,16 @@ func (c *Container) Execute(args ...string) ([]byte, error) {
 	}
 
 	return output, nil
-	/*
-		cargs := makeNullTerminatedArgs(args)
-		if cargs == nil {
-			return ErrAllocationFailed
-		}
-		defer freeNullTerminatedArgs(cargs, len(args))
-
-		if !bool(C.go_lxc_start(c.container, 1, cargs)) {
-			return ErrExecuteFailed
-		}
-		return nil
-	*/
 }
 
 // Stop stops the container.
 func (c *Container) Stop() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if !bool(C.go_lxc_stop(c.container)) {
 		return ErrStopFailed
@@ -503,12 +550,12 @@ func (c *Container) Stop() error {
 
 // Reboot reboots the container.
 func (c *Container) Reboot() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if !bool(C.go_lxc_reboot(c.container)) {
 		return ErrRebootFailed
@@ -518,11 +565,12 @@ func (c *Container) Reboot() error {
 
 // Shutdown shuts down the container.
 func (c *Container) Shutdown(timeout time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return err
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if !bool(C.go_lxc_shutdown(c.container, C.int(timeout.Seconds()))) {
 		return ErrShutdownFailed
@@ -532,12 +580,12 @@ func (c *Container) Shutdown(timeout time.Duration) error {
 
 // Destroy destroys the container.
 func (c *Container) Destroy() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isDefined | isNotRunning); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if !bool(C.go_lxc_destroy(c.container)) {
 		return ErrDestroyFailed
@@ -547,12 +595,12 @@ func (c *Container) Destroy() error {
 
 // DestroyWithAllSnapshots destroys the container and its snapshots
 func (c *Container) DestroyWithAllSnapshots() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isDefined | isNotRunning | isGreaterEqualThanLXC11); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if !bool(C.go_lxc_destroy_with_snapshots(c.container)) {
 		return ErrDestroyWithAllSnapshotsFailed
@@ -562,6 +610,9 @@ func (c *Container) DestroyWithAllSnapshots() error {
 
 // Clone clones the container using given arguments with specified backend.
 func (c *Container) Clone(name string, options CloneOptions) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	// FIXME: bdevdata, newsize and hookargs
 	//
 	// bdevdata:
@@ -576,9 +627,6 @@ func (c *Container) Clone(name string, options CloneOptions) error {
 	if err := c.makeSure(isDefined | isNotRunning); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	// use Directory backend if not set
 	if options.Backend == 0 {
@@ -619,12 +667,12 @@ func (c *Container) Clone(name string, options CloneOptions) error {
 
 // Rename renames the container.
 func (c *Container) Rename(name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isDefined | isNotRunning); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
@@ -658,11 +706,7 @@ func (c *Container) ConfigFileName() string {
 	return C.GoString(configFileName)
 }
 
-// ConfigItem returns the value of the given config item.
-func (c *Container) ConfigItem(key string) []string {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
+func (c *Container) configItem(key string) []string {
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 
@@ -674,11 +718,15 @@ func (c *Container) ConfigItem(key string) []string {
 	return strings.Split(ret, "\n")
 }
 
-// SetConfigItem sets the value of the given config item.
-func (c *Container) SetConfigItem(key string, value string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// ConfigItem returns the value of the given config item.
+func (c *Container) ConfigItem(key string) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
+	return c.configItem(key)
+}
+
+func (c *Container) setConfigItem(key string, value string) error {
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 
@@ -691,11 +739,15 @@ func (c *Container) SetConfigItem(key string, value string) error {
 	return nil
 }
 
-// RunningConfigItem returns the value of the given config item.
-func (c *Container) RunningConfigItem(key string) []string {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+// SetConfigItem sets the value of the given config item.
+func (c *Container) SetConfigItem(key string, value string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
+	return c.setConfigItem(key, value)
+}
+
+func (c *Container) runningConfigItem(key string) []string {
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 
@@ -707,11 +759,15 @@ func (c *Container) RunningConfigItem(key string) []string {
 	return strings.Split(ret, "\n")
 }
 
-// CgroupItem returns the value of the given cgroup subsystem value.
-func (c *Container) CgroupItem(key string) []string {
+// RunningConfigItem returns the value of the given config item.
+func (c *Container) RunningConfigItem(key string) []string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	return c.runningConfigItem(key)
+}
+
+func (c *Container) cgroupItem(key string) []string {
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 
@@ -723,11 +779,7 @@ func (c *Container) CgroupItem(key string) []string {
 	return strings.Split(ret, "\n")
 }
 
-// SetCgroupItem sets the value of given cgroup subsystem value.
-func (c *Container) SetCgroupItem(key string, value string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
+func (c *Container) setCgroupItem(key string, value string) error {
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 
@@ -738,6 +790,22 @@ func (c *Container) SetCgroupItem(key string, value string) error {
 		return ErrSettingCgroupItemFailed
 	}
 	return nil
+}
+
+// CgroupItem returns the value of the given cgroup subsystem value.
+func (c *Container) CgroupItem(key string) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.cgroupItem(key)
+}
+
+// SetCgroupItem sets the value of given cgroup subsystem value.
+func (c *Container) SetCgroupItem(key string, value string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.setCgroupItem(key, value)
 }
 
 // ClearConfig completely clears the containers in-memory configuration.
@@ -757,7 +825,7 @@ func (c *Container) ClearConfigItem(key string) error {
 	defer C.free(unsafe.Pointer(ckey))
 
 	if !bool(C.go_lxc_clear_config_item(c.container, ckey)) {
-		return ErrClearingCgroupItemFailed
+		return ErrClearingConfigItemFailed
 	}
 	return nil
 }
@@ -799,11 +867,7 @@ func (c *Container) LoadConfigFile(path string) error {
 	return nil
 }
 
-// SaveConfigFile saves the configuration file to given path.
-func (c *Container) SaveConfigFile(path string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
+func (c *Container) saveConfigFile(path string) error {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 
@@ -813,12 +877,24 @@ func (c *Container) SaveConfigFile(path string) error {
 	return nil
 }
 
+// SaveConfigFile saves the configuration file to given path.
+func (c *Container) SaveConfigFile(path string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.saveConfigFile(path)
+}
+
+func (c *Container) configPath() string {
+	return C.GoString(C.go_lxc_get_config_path(c.container))
+}
+
 // ConfigPath returns the configuration file's path.
 func (c *Container) ConfigPath() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return C.GoString(C.go_lxc_get_config_path(c.container))
+	return c.configPath()
 }
 
 // SetConfigPath sets the configuration file's path.
@@ -837,6 +913,9 @@ func (c *Container) SetConfigPath(path string) error {
 
 // MemoryUsage returns memory usage of the container in bytes.
 func (c *Container) MemoryUsage() (ByteSize, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
@@ -846,6 +925,9 @@ func (c *Container) MemoryUsage() (ByteSize, error) {
 
 // MemoryLimit returns memory limit of the container in bytes.
 func (c *Container) MemoryLimit() (ByteSize, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
@@ -855,6 +937,9 @@ func (c *Container) MemoryLimit() (ByteSize, error) {
 
 // SetMemoryLimit sets memory limit of the container in bytes.
 func (c *Container) SetMemoryLimit(limit ByteSize) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return err
 	}
@@ -864,6 +949,9 @@ func (c *Container) SetMemoryLimit(limit ByteSize) error {
 
 // SoftMemoryLimit returns soft memory limit of the container in bytes.
 func (c *Container) SoftMemoryLimit() (ByteSize, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
@@ -873,6 +961,9 @@ func (c *Container) SoftMemoryLimit() (ByteSize, error) {
 
 // SetSoftMemoryLimit sets soft  memory limit of the container in bytes.
 func (c *Container) SetSoftMemoryLimit(limit ByteSize) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return err
 	}
@@ -882,6 +973,9 @@ func (c *Container) SetSoftMemoryLimit(limit ByteSize) error {
 
 // KernelMemoryUsage returns current kernel memory allocation of the container in bytes.
 func (c *Container) KernelMemoryUsage() (ByteSize, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
@@ -891,6 +985,9 @@ func (c *Container) KernelMemoryUsage() (ByteSize, error) {
 
 // KernelMemoryLimit returns kernel memory limit of the container in bytes.
 func (c *Container) KernelMemoryLimit() (ByteSize, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
@@ -900,6 +997,9 @@ func (c *Container) KernelMemoryLimit() (ByteSize, error) {
 
 // SetKernelMemoryLimit sets kernel memory limit of the container in bytes.
 func (c *Container) SetKernelMemoryLimit(limit ByteSize) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return err
 	}
@@ -909,6 +1009,9 @@ func (c *Container) SetKernelMemoryLimit(limit ByteSize) error {
 
 // MemorySwapUsage returns memory+swap usage of the container in bytes.
 func (c *Container) MemorySwapUsage() (ByteSize, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
@@ -918,6 +1021,9 @@ func (c *Container) MemorySwapUsage() (ByteSize, error) {
 
 // MemorySwapLimit returns the memory+swap limit of the container in bytes.
 func (c *Container) MemorySwapLimit() (ByteSize, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
@@ -927,6 +1033,9 @@ func (c *Container) MemorySwapLimit() (ByteSize, error) {
 
 // SetMemorySwapLimit sets memory+swap limit of the container in bytes.
 func (c *Container) SetMemorySwapLimit(limit ByteSize) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return err
 	}
@@ -936,14 +1045,19 @@ func (c *Container) SetMemorySwapLimit(limit ByteSize) error {
 
 // BlkioUsage returns number of bytes transferred to/from the disk by the container.
 func (c *Container) BlkioUsage() (ByteSize, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	ioServiceBytes := c.cgroupItem("blkio.throttle.io_service_bytes")
+	if ioServiceBytes[0] == "" {
+		return 0, nil
+	}
 
-	for _, v := range c.CgroupItem("blkio.throttle.io_service_bytes") {
+	for _, v := range ioServiceBytes {
 		b := strings.Split(v, " ")
 		if b[0] == "Total" {
 			blkioUsed, err := strconv.ParseFloat(b[1], 64)
@@ -959,14 +1073,19 @@ func (c *Container) BlkioUsage() (ByteSize, error) {
 // CPUTime returns the total CPU time (in nanoseconds) consumed by all tasks
 // in this cgroup (including tasks lower in the hierarchy).
 func (c *Container) CPUTime() (time.Duration, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	usage := c.cgroupItem("cpuacct.usage")
+	if usage[0] == "" {
+		return 0, nil
+	}
 
-	cpuUsage, err := strconv.ParseInt(c.CgroupItem("cpuacct.usage")[0], 10, 64)
+	cpuUsage, err := strconv.ParseInt(usage[0], 10, 64)
 	if err != nil {
 		return -1, err
 	}
@@ -976,15 +1095,20 @@ func (c *Container) CPUTime() (time.Duration, error) {
 // CPUTimePerCPU returns the CPU time (in nanoseconds) consumed on each CPU by
 // all tasks in this cgroup (including tasks lower in the hierarchy).
 func (c *Container) CPUTimePerCPU() (map[int]time.Duration, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return nil, err
 	}
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	usagePerCPU := c.cgroupItem("cpuacct.usage_percpu")
+	if usagePerCPU[0] == "" {
+		return map[int]time.Duration{0: 0}, nil
+	}
 
 	cpuTimes := make(map[int]time.Duration)
-	for i, v := range strings.Split(c.CgroupItem("cpuacct.usage_percpu")[0], " ") {
+	for i, v := range strings.Split(usagePerCPU[0], " ") {
 		cpuUsage, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
 			return nil, err
@@ -997,19 +1121,23 @@ func (c *Container) CPUTimePerCPU() (map[int]time.Duration, error) {
 // CPUStats returns the number of CPU cycles (in the units defined by USER_HZ on the system)
 // consumed by tasks in this cgroup and its children in both user mode and system (kernel) mode.
 func (c *Container) CPUStats() (map[string]int64, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return nil, err
 	}
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	stat := c.cgroupItem("cpuacct.stat")
+	if stat[0] == "" {
+		return map[string]int64{"user": 0, "system": 0}, nil
+	}
 
-	cpuStat := c.CgroupItem("cpuacct.stat")
-	user, err := strconv.ParseInt(strings.Split(cpuStat[0], "user ")[1], 10, 64)
+	user, err := strconv.ParseInt(strings.Split(stat[0], "user ")[1], 10, 64)
 	if err != nil {
 		return nil, err
 	}
-	system, err := strconv.ParseInt(strings.Split(cpuStat[1], "system ")[1], 10, 64)
+	system, err := strconv.ParseInt(strings.Split(stat[1], "system ")[1], 10, 64)
 	if err != nil {
 		return nil, err
 	}
@@ -1025,13 +1153,13 @@ func (c *Container) CPUStats() (map[string]int64, error) {
 // indicate that it is done with the allocated console so that it can
 // be allocated by another caller.
 func (c *Container) ConsoleFd(ttynum int) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	// FIXME: Make idiomatic
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	ret := int(C.go_lxc_console_getfd(c.container, C.int(ttynum)))
 	if ret < 0 {
@@ -1044,12 +1172,12 @@ func (c *Container) ConsoleFd(ttynum int) (int, error) {
 //
 // This function will not return until the console has been exited by the user.
 func (c *Container) Console(options ConsoleOptions) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	ret := bool(C.go_lxc_console(c.container,
 		C.int(options.Tty),
@@ -1067,12 +1195,12 @@ func (c *Container) Console(options ConsoleOptions) error {
 // AttachShell attaches a shell to the container.
 // It clears all environment variables before attaching.
 func (c *Container) AttachShell(options AttachOptions) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	cenv := makeNullTerminatedArgs(options.Env)
 	if cenv == nil {
@@ -1108,11 +1236,7 @@ func (c *Container) AttachShell(options AttachOptions) error {
 	return nil
 }
 
-// RunCommandStatus attachs a shell and runs the command within the container.
-// The process will wait for the command to finish and return the result of
-// waitpid(), i.e. the process' exit status. An error is returned only when
-// invocation of the command completely fails.
-func (c *Container) RunCommandStatus(args []string, options AttachOptions) (int, error) {
+func (c *Container) runCommandStatus(args []string, options AttachOptions) (int, error) {
 	if len(args) == 0 {
 		return -1, ErrInsufficientNumberOfArguments
 	}
@@ -1120,9 +1244,6 @@ func (c *Container) RunCommandStatus(args []string, options AttachOptions) (int,
 	if err := c.makeSure(isRunning); err != nil {
 		return -1, err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	cargs := makeNullTerminatedArgs(args)
 	if cargs == nil {
@@ -1164,11 +1285,84 @@ func (c *Container) RunCommandStatus(args []string, options AttachOptions) (int,
 	return ret, nil
 }
 
+// RunCommandStatus attachs a shell and runs the command within the container.
+// The process will wait for the command to finish and return the result of
+// waitpid(), i.e. the process' exit status. An error is returned only when
+// invocation of the command completely fails.
+func (c *Container) RunCommandStatus(args []string, options AttachOptions) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.runCommandStatus(args, options)
+}
+
+// RunCommandNoWait runs the given command and returns without waiting it to finish.
+func (c *Container) RunCommandNoWait(args []string, options AttachOptions) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(args) == 0 {
+		return -1, ErrInsufficientNumberOfArguments
+	}
+
+	if err := c.makeSure(isRunning); err != nil {
+		return -1, err
+	}
+
+	cargs := makeNullTerminatedArgs(args)
+	if cargs == nil {
+		return -1, ErrAllocationFailed
+	}
+	defer freeNullTerminatedArgs(cargs, len(args))
+
+	cenv := makeNullTerminatedArgs(options.Env)
+	if cenv == nil {
+		return -1, ErrAllocationFailed
+	}
+	defer freeNullTerminatedArgs(cenv, len(options.Env))
+
+	cenvToKeep := makeNullTerminatedArgs(options.EnvToKeep)
+	if cenvToKeep == nil {
+		return -1, ErrAllocationFailed
+	}
+	defer freeNullTerminatedArgs(cenvToKeep, len(options.EnvToKeep))
+
+	cwd := C.CString(options.Cwd)
+	defer C.free(unsafe.Pointer(cwd))
+
+	var attachedPid C.pid_t
+	ret := int(C.go_lxc_attach_no_wait(
+		c.container,
+		C.bool(options.ClearEnv),
+		C.int(options.Namespaces),
+		C.long(options.Arch),
+		C.uid_t(options.UID),
+		C.gid_t(options.GID),
+		C.int(options.StdinFd),
+		C.int(options.StdoutFd),
+		C.int(options.StderrFd),
+		cwd,
+		cenv,
+		cenvToKeep,
+		cargs,
+		&attachedPid,
+	))
+
+	if ret < 0 {
+		return -1, ErrAttachFailed
+	}
+
+	return int(attachedPid), nil
+}
+
 // RunCommand attachs a shell and runs the command within the container.
 // The process will wait for the command to finish and return a success status. An error
 // is returned only when invocation of the command completely fails.
 func (c *Container) RunCommand(args []string, options AttachOptions) (bool, error) {
-	ret, err := c.RunCommandStatus(args, options)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ret, err := c.runCommandStatus(args, options)
 	if err != nil {
 		return false, err
 	}
@@ -1180,12 +1374,12 @@ func (c *Container) RunCommand(args []string, options AttachOptions) (bool, erro
 
 // Interfaces returns the names of the network interfaces.
 func (c *Container) Interfaces() ([]string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return nil, err
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	result := C.go_lxc_get_interfaces(c.container)
 	if result == nil {
@@ -1196,27 +1390,32 @@ func (c *Container) Interfaces() ([]string, error) {
 
 // InterfaceStats returns the stats about container's network interfaces
 func (c *Container) InterfaceStats() (map[string]map[string]ByteSize, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return nil, err
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	var interfaceName string
 
 	statistics := make(map[string]map[string]ByteSize)
 
-	for i := 0; i < len(c.ConfigItem("lxc.network")); i++ {
-		interfaceType := c.RunningConfigItem(fmt.Sprintf("lxc.network.%d.type", i))
+	netPrefix := "lxc.net"
+	if !VersionAtLeast(2, 1, 0) {
+		netPrefix = "lxc.network"
+	}
+
+	for i := 0; i < len(c.configItem(netPrefix)); i++ {
+		interfaceType := c.runningConfigItem(fmt.Sprintf("%s.%d.type", netPrefix, i))
 		if interfaceType == nil {
 			continue
 		}
 
 		if interfaceType[0] == "veth" {
-			interfaceName = c.RunningConfigItem(fmt.Sprintf("lxc.network.%d.veth.pair", i))[0]
+			interfaceName = c.runningConfigItem(fmt.Sprintf("%s.%d.veth.pair", netPrefix, i))[0]
 		} else {
-			interfaceName = c.RunningConfigItem(fmt.Sprintf("lxc.network.%d.link", i))[0]
+			interfaceName = c.runningConfigItem(fmt.Sprintf("%s.%d.link", netPrefix, i))[0]
 		}
 
 		for _, v := range []string{"rx", "tx"} {
@@ -1243,12 +1442,12 @@ func (c *Container) InterfaceStats() (map[string]map[string]ByteSize, error) {
 
 // IPAddress returns the IP address of the given network interface.
 func (c *Container) IPAddress(interfaceName string) ([]string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return nil, err
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	cinterface := C.CString(interfaceName)
 	defer C.free(unsafe.Pointer(cinterface))
@@ -1262,12 +1461,12 @@ func (c *Container) IPAddress(interfaceName string) ([]string, error) {
 
 // IPv4Address returns the IPv4 address of the given network interface.
 func (c *Container) IPv4Address(interfaceName string) ([]string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return nil, err
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	cinterface := C.CString(interfaceName)
 	defer C.free(unsafe.Pointer(cinterface))
@@ -1284,12 +1483,12 @@ func (c *Container) IPv4Address(interfaceName string) ([]string, error) {
 
 // IPv6Address returns the IPv6 address of the given network interface.
 func (c *Container) IPv6Address(interfaceName string) ([]string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return nil, err
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	cinterface := C.CString(interfaceName)
 	defer C.free(unsafe.Pointer(cinterface))
@@ -1306,9 +1505,12 @@ func (c *Container) IPv6Address(interfaceName string) ([]string, error) {
 
 // WaitIPAddresses waits until IPAddresses call returns something or time outs
 func (c *Container) WaitIPAddresses(timeout time.Duration) ([]string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	now := time.Now()
 	for {
-		if result, err := c.IPAddresses(); err == nil && len(result) > 0 {
+		if result, err := c.ipAddresses(); err == nil && len(result) > 0 {
 			return result, nil
 		}
 		// Python API sleeps 1 second as well
@@ -1320,14 +1522,10 @@ func (c *Container) WaitIPAddresses(timeout time.Duration) ([]string, error) {
 	}
 }
 
-// IPAddresses returns all IP addresses.
-func (c *Container) IPAddresses() ([]string, error) {
+func (c *Container) ipAddresses() ([]string, error) {
 	if err := c.makeSure(isRunning); err != nil {
 		return nil, err
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	result := C.go_lxc_get_ips(c.container, nil, nil, 0)
 	if result == nil {
@@ -1337,14 +1535,22 @@ func (c *Container) IPAddresses() ([]string, error) {
 
 }
 
+// IPAddresses returns all IP addresses.
+func (c *Container) IPAddresses() ([]string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.ipAddresses()
+}
+
 // IPv4Addresses returns all IPv4 addresses.
 func (c *Container) IPv4Addresses() ([]string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return nil, err
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	cfamily := C.CString("inet")
 	defer C.free(unsafe.Pointer(cfamily))
@@ -1358,12 +1564,12 @@ func (c *Container) IPv4Addresses() ([]string, error) {
 
 // IPv6Addresses returns all IPv6 addresses.
 func (c *Container) IPv6Addresses() ([]string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if err := c.makeSure(isRunning); err != nil {
 		return nil, err
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	cfamily := C.CString("inet6")
 	defer C.free(unsafe.Pointer(cfamily))
@@ -1377,25 +1583,58 @@ func (c *Container) IPv6Addresses() ([]string, error) {
 
 // LogFile returns the name of the logfile.
 func (c *Container) LogFile() string {
-	return c.ConfigItem("lxc.logfile")[0]
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if VersionAtLeast(2, 1, 0) {
+		return c.configItem("lxc.log.file")[0]
+	}
+
+	return c.configItem("lxc.logfile")[0]
 }
 
 // SetLogFile sets the name of the logfile.
 func (c *Container) SetLogFile(filename string) error {
-	if err := c.SetConfigItem("lxc.logfile", filename); err != nil {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var err error
+	if VersionAtLeast(2, 1, 0) {
+		err = c.setConfigItem("lxc.log.file", filename)
+	} else {
+		err = c.setConfigItem("lxc.logfile", filename)
+	}
+	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // LogLevel returns the level of the logfile.
 func (c *Container) LogLevel() LogLevel {
-	return logLevelMap[c.ConfigItem("lxc.loglevel")[0]]
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if VersionAtLeast(2, 1, 0) {
+		return logLevelMap[c.configItem("lxc.log.level")[0]]
+	}
+
+	return logLevelMap[c.configItem("lxc.loglevel")[0]]
 }
 
 // SetLogLevel sets the level of the logfile.
 func (c *Container) SetLogLevel(level LogLevel) error {
-	if err := c.SetConfigItem("lxc.loglevel", level.String()); err != nil {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var err error
+	if VersionAtLeast(2, 1, 0) {
+		err = c.setConfigItem("lxc.log.level", level.String())
+	} else {
+		err = c.setConfigItem("lxc.loglevel", level.String())
+	}
+	if err != nil {
 		return err
 	}
 	return nil
@@ -1403,12 +1642,12 @@ func (c *Container) SetLogLevel(level LogLevel) error {
 
 // AddDeviceNode adds specified device to the container.
 func (c *Container) AddDeviceNode(source string, destination ...string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning | isPrivileged); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	csource := C.CString(source)
 	defer C.free(unsafe.Pointer(csource))
@@ -1427,17 +1666,16 @@ func (c *Container) AddDeviceNode(source string, destination ...string) error {
 		return ErrAddDeviceNodeFailed
 	}
 	return nil
-
 }
 
 // RemoveDeviceNode removes the specified device from the container.
 func (c *Container) RemoveDeviceNode(source string, destination ...string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning | isPrivileged); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	csource := C.CString(source)
 	defer C.free(unsafe.Pointer(csource))
@@ -1460,6 +1698,9 @@ func (c *Container) RemoveDeviceNode(source string, destination ...string) error
 
 // Checkpoint checkpoints the container.
 func (c *Container) Checkpoint(opts CheckpointOptions) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning | isGreaterEqualThanLXC11); err != nil {
 		return err
 	}
@@ -1478,6 +1719,9 @@ func (c *Container) Checkpoint(opts CheckpointOptions) error {
 
 // Restore restores the container from a checkpoint.
 func (c *Container) Restore(opts RestoreOptions) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isGreaterEqualThanLXC11); err != nil {
 		return err
 	}
@@ -1493,9 +1737,19 @@ func (c *Container) Restore(opts RestoreOptions) error {
 	return nil
 }
 
+// Migrate migrates the container.
 func (c *Container) Migrate(cmd uint, opts MigrateOptions) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isNotDefined | isGreaterEqualThanLXC20); err != nil {
 		return err
+	}
+
+	if cmd != MIGRATE_RESTORE {
+		if err := c.makeSure(isRunning); err != nil {
+			return err
+		}
 	}
 
 	cdirectory := C.CString(opts.Directory)
@@ -1525,14 +1779,15 @@ func (c *Container) Migrate(cmd uint, opts MigrateOptions) error {
 	}
 
 	extras := C.struct_extra_migrate_opts{
-		preserves_inodes: C.bool(opts.PreservesInodes),
-		action_script:    cActionScript,
-		ghost_limit:      C.uint64_t(opts.GhostLimit),
+		preserves_inodes:  C.bool(opts.PreservesInodes),
+		action_script:     cActionScript,
+		ghost_limit:       C.uint64_t(opts.GhostLimit),
+		features_to_check: C.uint64_t(opts.FeaturesToCheck),
 	}
 
 	ret := C.int(C.go_lxc_migrate(c.container, C.uint(cmd), &copts, &extras))
 	if ret != 0 {
-		return fmt.Errorf("migration failed %d\n", ret)
+		return fmt.Errorf("migration failed %d", ret)
 	}
 
 	return nil
@@ -1540,12 +1795,12 @@ func (c *Container) Migrate(cmd uint, opts MigrateOptions) error {
 
 // AttachInterface attaches specifed netdev to the container.
 func (c *Container) AttachInterface(source, destination string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning | isPrivileged | isGreaterEqualThanLXC11); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	csource := C.CString(source)
 	defer C.free(unsafe.Pointer(csource))
@@ -1561,12 +1816,12 @@ func (c *Container) AttachInterface(source, destination string) error {
 
 // DetachInterface detaches specifed netdev from the container.
 func (c *Container) DetachInterface(source string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning | isPrivileged | isGreaterEqualThanLXC11); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	csource := C.CString(source)
 	defer C.free(unsafe.Pointer(csource))
@@ -1579,12 +1834,12 @@ func (c *Container) DetachInterface(source string) error {
 
 // DetachInterfaceRename detaches specifed netdev from the container and renames it.
 func (c *Container) DetachInterfaceRename(source, target string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if err := c.makeSure(isRunning | isPrivileged | isGreaterEqualThanLXC11); err != nil {
 		return err
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	csource := C.CString(source)
 	defer C.free(unsafe.Pointer(csource))
@@ -1596,4 +1851,44 @@ func (c *Container) DetachInterfaceRename(source, target string) error {
 		return ErrDetachInterfaceFailed
 	}
 	return nil
+}
+
+// ConsoleLog allows to perform operations on the container's in-memory console
+// buffer.
+func (c *Container) ConsoleLog(opt ConsoleLogOptions) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	cl := C.struct_lxc_console_log{
+		clear:         C.bool(opt.ClearLog),
+		read:          C.bool(opt.ReadLog),
+		data:          nil,
+		write_logfile: C.bool(opt.WriteToLogFile),
+	}
+	// CGO is a fickle little beast:
+	// We need to manually allocate memory here that we pass to C. If we
+	// were to pass a GO pointer by passing a C.uint64_t pointer we'd end in
+	// the situation where we have a GO pointer that points to a GO pointer.
+	// Go will freak out when this happens. So give C its own memory.
+	var buf unsafe.Pointer
+	buf = C.malloc(C.sizeof_uint64_t)
+	if buf == nil {
+		return nil, syscall.ENOMEM
+	}
+	defer C.free(buf)
+
+	cl.read_max = (*C.uint64_t)(buf)
+	*cl.read_max = C.uint64_t(opt.ReadMax)
+
+	ret := C.go_lxc_console_log(c.container, &cl)
+	if ret < 0 {
+		return nil, syscall.Errno(-ret)
+	}
+
+	numBytes := C.int(*cl.read_max)
+	if C.uint64_t(numBytes) != *cl.read_max {
+		return nil, syscall.ERANGE
+	}
+
+	return C.GoBytes(unsafe.Pointer(cl.data), numBytes), nil
 }

--- a/vendor/gopkg.in/lxc/go-lxc.v2/error.go
+++ b/vendor/gopkg.in/lxc/go-lxc.v2/error.go
@@ -16,6 +16,7 @@ var (
 	ErrAttachInterfaceFailed         = NewError("attaching specified netdev to the container failed")
 	ErrBlkioUsage                    = NewError("BlkioUsage for the container failed")
 	ErrCheckpointFailed              = NewError("checkpoint failed")
+	ErrClearingConfigItemFailed      = NewError("clearing config item for the container failed")
 	ErrClearingCgroupItemFailed      = NewError("clearing cgroup item for the container failed")
 	ErrCloneFailed                   = NewError("cloning the container failed")
 	ErrCloseAllFdsFailed             = NewError("setting close_all_fds flag for container failed")

--- a/vendor/gopkg.in/lxc/go-lxc.v2/lxc-binding.h
+++ b/vendor/gopkg.in/lxc/go-lxc.v2/lxc-binding.h
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a LGPLv2.1
 // license that can be found in the LICENSE file.
 
+#define VERSION_AT_LEAST(major, minor, micro)							\
+	((LXC_DEVEL == 1) || (!(major > LXC_VERSION_MAJOR ||					\
+	major == LXC_VERSION_MAJOR && minor > LXC_VERSION_MINOR ||				\
+	major == LXC_VERSION_MAJOR && minor == LXC_VERSION_MINOR && micro > LXC_VERSION_MICRO)))
+
 extern bool go_lxc_add_device_node(struct lxc_container *c, const char *src_path, const char *dest_path);
 extern void go_lxc_clear_config(struct lxc_container *c);
 extern bool go_lxc_clear_config_item(struct lxc_container *c, const char *key);
@@ -60,12 +65,24 @@ extern int go_lxc_attach(struct lxc_container *c,
 		char *initial_cwd,
 		char **extra_env_vars,
 		char **extra_keep_env);
+extern int go_lxc_attach_no_wait(struct lxc_container *c,
+		bool clear_env,
+		int namespaces,
+		long personality,
+		uid_t uid, gid_t gid,
+		int stdinfd, int stdoutfd, int stderrfd,
+		char *initial_cwd,
+		char **extra_env_vars,
+		char **extra_keep_env,
+		const char * const argv[],
+		pid_t *attached_pid);
 extern int go_lxc_console_getfd(struct lxc_container *c, int ttynum);
 extern int go_lxc_snapshot_list(struct lxc_container *c, struct lxc_snapshot **ret);
 extern int go_lxc_snapshot(struct lxc_container *c);
 extern pid_t go_lxc_init_pid(struct lxc_container *c);
 extern bool go_lxc_checkpoint(struct lxc_container *c, char *directory, bool stop, bool verbose);
 extern bool go_lxc_restore(struct lxc_container *c, char *directory, bool verbose);
+extern bool go_lxc_config_item_is_supported(const char *key);
 
 /* n.b. that we're just adding the fields here to shorten the definition
  * of go_lxc_migrate; in the case where we don't have the ->migrate API call,
@@ -89,8 +106,21 @@ struct extra_migrate_opts {
 	bool preserves_inodes;
 	char *action_script;
 	uint64_t ghost_limit;
+	uint64_t features_to_check;
 };
 int go_lxc_migrate(struct lxc_container *c, unsigned int cmd, struct migrate_opts *opts, struct extra_migrate_opts *extras);
 
 extern bool go_lxc_attach_interface(struct lxc_container *c, const char *dev, const char *dst_dev);
 extern bool go_lxc_detach_interface(struct lxc_container *c, const char *dev, const char *dst_dev);
+
+#if !VERSION_AT_LEAST(3, 0, 0)
+struct lxc_console_log {
+	bool clear;
+	bool read;
+	uint64_t *read_max;
+	char *data;
+	bool write_logfile;
+};
+#endif
+
+extern int go_lxc_console_log(struct lxc_container *c, struct lxc_console_log *log);

--- a/vendor/gopkg.in/lxc/go-lxc.v2/options.go
+++ b/vendor/gopkg.in/lxc/go-lxc.v2/options.go
@@ -142,7 +142,7 @@ type ConsoleOptions struct {
 	EscapeCharacter rune
 }
 
-// DefailtConsoleOptions is a convenient set of options to be used.
+// DefaultConsoleOptions is a convenient set of options to be used.
 var DefaultConsoleOptions = ConsoleOptions{
 	Tty:             -1,
 	StdinFd:         os.Stdin.Fd(),
@@ -175,25 +175,35 @@ var DefaultCloneOptions = CloneOptions{
 	Backend: Directory,
 }
 
-// CheckpointOptions type is used for defining checkpoint options for CRIU
+// CheckpointOptions type is used for defining checkpoint options for CRIU.
 type CheckpointOptions struct {
 	Directory string
 	Stop      bool
 	Verbose   bool
 }
 
-// RestoreOptions type is used for defining restore options for CRIU
+// RestoreOptions type is used for defining restore options for CRIU.
 type RestoreOptions struct {
 	Directory string
 	Verbose   bool
 }
 
+// MigrateOptions type is used for defining migrate options.
 type MigrateOptions struct {
 	Directory       string
+	PredumpDir      string
+	ActionScript    string
 	Verbose         bool
 	Stop            bool
-	PredumpDir      string
 	PreservesInodes bool
-	ActionScript    string
 	GhostLimit      uint64
+	FeaturesToCheck CriuFeatures
+}
+
+// ConsoleLogOptioins type is used for defining console log options.
+type ConsoleLogOptions struct {
+	ClearLog       bool
+	ReadLog        bool
+	ReadMax        uint64
+	WriteToLogFile bool
 }

--- a/vendor/gopkg.in/lxc/go-lxc.v2/type.go
+++ b/vendor/gopkg.in/lxc/go-lxc.v2/type.go
@@ -260,7 +260,15 @@ const (
 )
 
 const (
-	MIGRATE_PRE_DUMP = 0
-	MIGRATE_DUMP     = 1
-	MIGRATE_RESTORE  = 2
+	MIGRATE_PRE_DUMP      = 0
+	MIGRATE_DUMP          = 1
+	MIGRATE_RESTORE       = 2
+	MIGRATE_FEATURE_CHECK = 3
+)
+
+type CriuFeatures uint64
+
+const (
+	FEATURE_MEM_TRACK CriuFeatures = 1 << iota
+	FEATURE_LAZY_PAGES
 )

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -282,7 +282,7 @@
 		{"path":"google.golang.org/grpc/transport","checksumSHA1":"oFGr0JoquaPGVnV86fVL8MVTc3A=","revision":"0c41876308d45bc82e587965971e28be659a1aca","revisionTime":"2017-07-21T17:58:12Z"},
 		{"path":"gopkg.in/fsnotify.v1","checksumSHA1":"eIhF+hmL/XZhzTiAwhLD0M65vlY=","revision":"629574ca2a5df945712d3079857300b5e4da0236","revisionTime":"2016-10-11T02:33:12Z"},
 		{"path":"gopkg.in/inf.v0","checksumSHA1":"6f8MEU31llHM1sLM/GGH4/Qxu0A=","revision":"3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4","revisionTime":"2015-09-11T12:57:57Z"},
-		{"path":"gopkg.in/lxc/go-lxc.v2","checksumSHA1":"i97goLq3AIfUNB8l1hxGGMSW0+s=","revision":"f8a6938e600c634232eeef79dc04a1226f73a88b","revisionTime":"2016-08-03T16:52:18Z"},
+		{"path":"gopkg.in/lxc/go-lxc.v2","checksumSHA1":"d23S9c4VEcyZaJCjS7YOyTtmci4=","revision":"8741a7213cda0df1951283400247300e75abaf17","revisionTime":"2018-01-08T22:36:36Z"},
 		{"path":"gopkg.in/tomb.v1","checksumSHA1":"TO8baX+t1Qs7EmOYth80MkbKzFo=","revision":"dd632973f1e7218eb1089048e0798ec9ae7dceb8","revisionTime":"2014-10-24T13:56:13Z"},
 		{"path":"gopkg.in/tomb.v2","checksumSHA1":"WiyCOMvfzRdymImAJ3ME6aoYUdM=","revision":"14b3d72120e8d10ea6e6b7f87f7175734b1faab8","revisionTime":"2014-06-26T14:46:23Z"},
 		{"path":"gopkg.in/yaml.v2","checksumSHA1":"12GqsW8PiRPnezDDy0v4brZrndM=","revision":"a5b47d31c556af34a302ce5d659e6fea44d90de0","revisionTime":"2016-09-28T15:37:09Z"}


### PR DESCRIPTION
This is the code from mikemccracken/nomad on branch 'atom', which has been the 'master' for our use until this week.

The majority of the changes are in lxc.go, but it requires a rather large diff to update go-lxc so we can call StartExecute.