### PR TITLE
do not attempt to validate volumes config if it is not found

### DIFF
--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -219,14 +219,18 @@ func (d *LxcDriver) Validate(config map[string]interface{}) error {
 		if err := execFd.Validate(); err != nil {
 			return err
 		}
-		volumes, _ = execFd.GetOk("volumes")
+		volumes, ok = execFd.GetOk("volumes")
 	} else {
 		if err := fd.Validate(); err != nil {
 			return err
 		}
-		volumes, _ = fd.GetOk("volumes")
+		volumes, ok = fd.GetOk("volumes")
 	}
-	return d.validateVolumesConfig(volumes.([]interface{}))
+	if ok {
+		return d.validateVolumesConfig(volumes.([]interface{}))
+	} else {
+		return nil
+	}
 }
 
 func (d *LxcDriver) validateVolumesConfig(volumes []interface{}) error {


### PR DESCRIPTION
Fixes a panic if 'volumes' was not in the config

Signed-off-by: Michael McCracken <mikmccra@cisco.com>