### PR TITLE
lxc: call container.Release() after Destroy()

### DIFF
--- a/client/driver/lxc.go
+++ b/client/driver/lxc.go
@@ -929,7 +929,11 @@ DESTROY:
 	if err := h.container.Destroy(); err != nil {
 		h.logger.Printf("[ERR] driver.lxc: error destroying container %q: %v.", name, err)
 	} else {
-		h.logger.Printf("[INFO] driver.lxc: successfully destroyed container %q.", name)
+		if err := h.container.Release(); err != nil {
+			h.logger.Printf("[ERR] driver.lxc: failed to release container %q after successful destroy: %v", name, err)
+		} else {
+			h.logger.Printf("[INFO] driver.lxc: successfully destroyed and released container %q.", name)
+		}
 	}
 }
 


### PR DESCRIPTION
This was not required until a change in go-lxc about December 2018,
commit c60d39311ab40de320bfc67096b5f2f3806bf862.

https://github.com/lxc/go-lxc/commit/c60d39311ab40de320bfc67096b5f2f3806bf862 specifically.

Signed-off-by: Michael McCracken <mikmccra@cisco.com>